### PR TITLE
adding assignees and reviewers to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,6 @@ updates:
       interval: "daily"
     assignees:
       - "abalcobia"
+      - "fgmachado-ritain"
+    reviewers:
+      - "nosportugal/ccoe-aws-terraform"


### PR DESCRIPTION
# 📑 Description

- Adding `fgmachado-ritain` to assignees for dependabot pull requests.
- Adding `ccoe-aws-terraform` team as reviewer for dependabot pull requests. 
