### PR TITLE
Adding policies folder to validate and block terraform blacklisted providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM ghcr.io/runatlantis/atlantis:v0.26.0
 RUN apk add python3 --no-cache
+COPY ./policies /policies

--- a/policies/blacklist-providers.rego
+++ b/policies/blacklist-providers.rego
@@ -1,0 +1,15 @@
+package main
+
+##Blacklisted providers
+
+not_allowed_providers := {x | x := split(opa.runtime()["env"]["BLACKLIST_PROVIDERS"], ",")[_]}
+
+blacklist_providers[provider]{
+    provider := input.providers
+    not_allowed_providers[provider]
+}
+
+deny[msg] {
+    count(blacklist_providers) > 0
+    msg := sprintf("Module %s is not authorized", [blacklist_providers[_]])
+}

--- a/policies/blacklist-providers.sh
+++ b/policies/blacklist-providers.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+## Retrieve providers downloaded by terraform init
+providers_output=$(terraform providers)
+
+## Parse result to output only the provider names
+provider_names=$(echo "$providers_output" | grep -o 'provider\[.*\]' | awk -F ']' '{print $1"]"}' | sed 's/provider\[//;s/\]//')
+
+## Eliminate duplicate providers
+unique_provider_names=$(echo "$provider_names" | awk '!seen[$0]++')
+
+## Set policy directory
+POLICY_DIR="/policies/blacklist-providers.rego"
+
+## Loop through identified providers to run a conftest agains the blacklist-providers policy
+violated=false
+for provider in $unique_provider_names; do
+    json="{\"providers\": \"$provider\"}"
+    if ! conftest test -p "$POLICY_DIR" - <<< "$json" >/dev/null; then
+        violated=true
+        echo "$json" | conftest test -p "$POLICY_DIR" -
+    fi
+done
+
+## Check if the any provider was identified in the loop and exit with according error
+if [ "$violated" = true ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
Since we use multiple providers on our organization it was decided to take a blacklist approach to the solution that incorporates the next two files:

1 - Script to parse the result of terraform providers command, eliminate duplicates and loop a conftest validation through said providers.
2 - REGO policy that contains all providers that we want to blacklist.
